### PR TITLE
bug(CWCP-79): Unrecognized character when retrieving account details

### DIFF
--- a/src/Pages/AccountDetails.js
+++ b/src/Pages/AccountDetails.js
@@ -14,7 +14,7 @@ const AccountDetails = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(`http://localhost:8080/api/v1/cwcp/security/user-info/${userId}`);
+        const response = await fetch(`http://localhost:8080/api/v1/cwcp/security/user-info/auth0%7C${userId.slice(6)}`);
         
         if (!response.ok) {
           throw new Error('Error fetching user');

--- a/src/Pages/EditEmployee.js
+++ b/src/Pages/EditEmployee.js
@@ -96,7 +96,7 @@ const AddEmployee = () => {
                         <label for="pword" hidden={!changePassword}>Password</label> <br/>
                         <input type='password' placeholder="Password" id="pword" hidden={!changePassword} style={{backgroundColor:"#e7e4e4", border:0, boxShadow:"1px 1px 2px 1px #6A6A6A", borderRadius:2}}/> <br/>
                         <input type="submit" value="Save" style={{background:"rgb(17, 206, 17)", color:'white', marginTop:"5%", borderRadius:7, padding:"2px 25px", fontWeight:'bold'}} id="submitEmployee"/>
-                        <Button as={Link} to="/admin/employees" style={{background:"rgb(159, 160, 159)", color:'white', marginLeft:"5%", borderRadius:7, padding:"2px 25px", fontWeight:'bold', border:0}}>Cancel</Button>
+                        <Button as={Link} to="/admin/employees" style={{background:"rgb(159, 160, 159)", color:'white', marginLeft:"5%", borderRadius:7, padding:"2px 25px", fontWeight:'bold', border:0}} id="cancelBtn">Cancel</Button>
                     </form>
                 </div>
             </div>

--- a/src/Pages/Employees.js
+++ b/src/Pages/Employees.js
@@ -21,7 +21,7 @@ const Employees = () => {
         <div className="inventory-item">
           <img src={employee.picture} alt="Profile" className="profile-picture"/>
           <h3>{employee.name}</h3>
-          <Button as={Link} to={`/admin/editEmployee/${employee.user_id}`} className="custom-add-button" id="addEmployeeBtn"> {/*onClick={() => directToForm()}*/} 
+          <Button as={Link} to={`/admin/editEmployee/${employee.user_id}`} className="custom-add-button" id="editEmployeeBtn"> {/*onClick={() => directToForm()}*/} 
             Edit
           </Button>
         </div>


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/CWCP-79

Context:
This ticket is about fixing a small bug that only seems to happen on certain devices where the | character when sending the GET request is unrecognized.

Changes

- Replaced '|' with "%7C" in AccountDetails.js